### PR TITLE
Added version info

### DIFF
--- a/hdwallet/__init__.py
+++ b/hdwallet/__init__.py
@@ -7,3 +7,5 @@ from .hdwallet import (
 __all__ = [
     "HDWallet", "BIP32HDWallet", "BIP44HDWallet", "BIP49HDWallet", "BIP84HDWallet", "BIP141HDWallet"
 ]
+
+__version__ = "1.3.2"


### PR DESCRIPTION
With this update one can do
```
import hdwallet
print(hdwallet.__version__)
```

Reference
https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names