### PR TITLE
Add return statement to hdwallet.py

### DIFF
--- a/hdwallet/hdwallet.py
+++ b/hdwallet/hdwallet.py
@@ -483,7 +483,7 @@ class HDWallet:
 
         if hardened:
             self._path += ("/%d'" % index)
-            self._derive_key_by_index(index + BIP32KEY_HARDEN)
+            return self._derive_key_by_index(index + BIP32KEY_HARDEN)
         else:
             self._path += ("/%d" % index)
             return self._derive_key_by_index(index)


### PR DESCRIPTION
Hardened key by index is not returned in the from_index function of the HDWallet class. Added return statement so that the derived object will be returned.